### PR TITLE
fix(WinCE): fixes build issues for Windows CE

### DIFF
--- a/BitVectorExtensions.cs
+++ b/BitVectorExtensions.cs
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------------
+// LICENSE INFORMATION
+//
+// - This software is licensed under the MIT shared source license.
+// - The "official" source code for this project is maintained at http://oncfext.codeplex.com
+//
+// Copyright (c) 2010 OpenNETCF Consulting
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+// associated documentation files (the "Software"), to deal in the Software without restriction, 
+// including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial 
+// portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+// -------------------------------------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Collections.Specialized;
+
+namespace OpenNETCF
+{
+    public static class BitVectorExtensions
+    {
+        public static bool Channel(this BitVector8 data, int channel)
+        {
+            return ((data & (1 << channel)) == (uint)(1 << channel));
+        }
+
+        public static bool Channel(this BitVector16 data, int channel)
+        {
+            return ((data.Data & (1 << channel)) == (uint)(1 << channel));
+        }
+
+        public static bool Channel(this BitVector32 data, int channel)
+        {
+            return ((data.Data & (1 << channel)) == (uint)(1 << channel));
+        }
+    }
+}

--- a/OpenNETCF.Extensions.CF.csproj
+++ b/OpenNETCF.Extensions.CF.csproj
@@ -18,10 +18,14 @@
     <NativePlatformName>Windows CE</NativePlatformName>
     <FormFactorID>
     </FormFactorID>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <DeployDirPrefix>\</DeployDirPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -51,14 +55,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="OpenNETCF.Net, Version=2.3.0.11010, Culture=neutral, PublicKeyToken=e60dbea84bb431b7, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\thirdparty\OpenNETCF\CF\OpenNETCF.Net.dll</HintPath>
-    </Reference>
-    <Reference Include="OpenNETCF.WindowsCE.Messaging, Version=2.3.12283.0, Culture=neutral, PublicKeyToken=e60dbea84bb431b7, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\thirdparty\OpenNETCF\CF\OpenNETCF.WindowsCE.Messaging.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
@@ -84,7 +80,7 @@
     <Compile Include="DisposableBase.cs" />
     <Compile Include="DoNotSerializeAttribute.cs" />
     <Compile Include="EnumExtensions.cs" />
-    <Compile Include="FormsExtensions.cs" />
+    <Compile Include="FormsExtensions - CF.cs" />
     <Compile Include="MovingAverage.cs" />
     <Compile Include="SafeCollections\SafeDictionary.cs" />
     <Compile Include="SafeCollections\SafeEnumerable.cs" />
@@ -94,16 +90,13 @@
     <Compile Include="Metrics.cs" />
     <Compile Include="Parsers.cs" />
     <Compile Include="TypeExtensions.cs" />
-    <Compile Include="WaitHandleExtensions.cs" />
+    <Compile Include="WaitHandleExtensions - CF.cs" />
     <Compile Include="IEnumerableExtensions.cs" />
     <Compile Include="DirectoryInfoExtensions.cs" />
     <Compile Include="EncodingExtensions.cs" />
     <Compile Include="EventHandlerExtensions.cs" />
     <Compile Include="GenericEventArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="REST\CredentialCache_Phone.cs" />
-    <Compile Include="REST\DigestRestConnector.cs" />
-    <Compile Include="REST\RestConnector.cs" />
     <Compile Include="Switch.cs" />
     <Compile Include="Validation\Validate.cs" />
     <Compile Include="Validation\Validation.cs" />

--- a/SafeCollections/SafeList.cs
+++ b/SafeCollections/SafeList.cs
@@ -144,7 +144,11 @@ namespace System.Collections.Generic
         {
             get 
             {
+#if WindowsCE
+                if (Monitor.TryEnter(m_syncRoot))
+#else
                 if( Monitor.TryEnter(m_syncRoot,5000))
+#endif
                 {
                     try
                     {

--- a/StringExtensions.cs
+++ b/StringExtensions.cs
@@ -41,7 +41,11 @@ namespace System
 
         public static bool IsNullOrWhiteSpace(this string s)
         {
+#if WindowsCE
+            return s == null || string.IsNullOrEmpty(s.Trim());
+#else
             return string.IsNullOrWhiteSpace(s);
+#endif
         }
 
         public static bool Matches(this string s, string compareTo)

--- a/Validation/ValidationExtensions.cs
+++ b/Validation/ValidationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------------
 // LICENSE INFORMATION
 //
 // - This software is licensed under the MIT shared source license.
@@ -29,7 +29,6 @@ using System.Collections;
 using System.IO;
 using System.Diagnostics;
 using System.Reflection;
-using System.Linq.Expressions;
 
 namespace OpenNETCF
 {


### PR DESCRIPTION
Fixes #2:
- Removes sdf dll references (only needed for unused P2PQueueTrace classes)
- Re-add BitVectorExtensions
- Remove old source control bindings

I decided that the REST classes are probably better suited elsewhere, rather than re-adding them just for the CF project.